### PR TITLE
Update terraform step functions config to dynamically populate public subnet IDs in ASL code

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,7 +62,7 @@ module "step_functions" {
 
   # Inputs from VPC
   private_subnets = join(",", [for subnet in module.vpc.private_subnets : "\"${subnet}\""])
-  # TODO: Add public subnet and security group here
+  public_subnets  = join(",", [for subnet in module.vpc.public_subnets : "\"${subnet}\""])
 }
 
 # SNS Module: Manages SNS for notifications

--- a/terraform/step_functions/main.tf
+++ b/terraform/step_functions/main.tf
@@ -125,7 +125,7 @@ resource "aws_sfn_state_machine" "my_state_machine" {
           "AwsvpcConfiguration": {
             "Subnets": [
               ${var.private_subnets},
-              "subnet-0e35bf95056fc68c0"
+              ${var.public_subnets}
             ],
             "SecurityGroups": [
               "sg-02071dac5218410e0"

--- a/terraform/step_functions/variables.tf
+++ b/terraform/step_functions/variables.tf
@@ -36,3 +36,8 @@ variable private_subnets {
     type  = string
     description = "List of private subnet IDs"
 }
+
+variable public_subnets {
+    type  = string
+    description = "List of public subnet IDs"
+}

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -5,3 +5,7 @@ output "vpc_id" {
 output "private_subnets" {
   value = aws_subnet.private[*].id
 }
+
+output "public_subnets" {
+  value = aws_subnet.public[*].id
+}


### PR DESCRIPTION
Update Terraform step functions config to dynamically populate public subnet IDs in ASL code. based on findings outlined in https://github.com/mlogan914/sdtm-data-pipeline-aws_project/pull/16. See comment.