### PR TITLE
Added s3 Object Lambda PII Redaction

### DIFF
--- a/data/redacted/medication_use_symptoms_02102023_REDACTED.csv
+++ b/data/redacted/medication_use_symptoms_02102023_REDACTED.csv
@@ -1,0 +1,5 @@
+Patient_ID,Name,Email,Date,Time,Medications,Symptom_Score,Pain_Level,Symptoms,Location
+P001,********,******************,*************:30,NSAID,3,7,Cramping; Fatigue,********
+P002,***********,*********************,*************:00,NSAID,2,3,No Symptoms,***********
+P003,*************,***********************,*************:00,NSAID,4,9,Heavy Bleeding; Fatigue,*******
+P004,*************,***********************,*************:30,No Medication,1,2,Happy,*****

--- a/data/redacted/raw_patient_reported_outcomes_02102023_REDACTED.csv
+++ b/data/redacted/raw_patient_reported_outcomes_02102023_REDACTED.csv
@@ -1,0 +1,5 @@
+Patient_ID,Name,Email,Age,Gender,Date,Time,Location,Menstrual_Cycle_Symptoms,Medication_Taken,Pain_Score_Morning,Pain_Score_Evening,Mood,Activity_Level,Step_Count
+P001,********,******************,30,Female,*************:**,********,Heavy Bleeding; Fatigue,NSAID; Birth Control,7,8,Anxious,Low,3500
+P002,***********,*********************,25,Female,*************:**,***********,No Symptoms,NSAID,3,4,Normal,Moderate,5000
+P003,*************,***********************,32,Female,*************:**,*******,Heavy Bleeding; Cramping; Fatigue,NSAID,9,9,Sad,Very Low,1000
+P004,*************,***********************,40,Female,*************:**,*****,No Symptoms,No Medication,2,2,Happy,High,8000

--- a/data/redacted/raw_wearable_device_02102023_REDACTED.csv
+++ b/data/redacted/raw_wearable_device_02102023_REDACTED.csv
@@ -1,0 +1,5 @@
+Patient_ID,Device_ID,Date,Time,Resting_Heart_Rate,Step_Count,Activity_Level,Location,Duration_Of_Sleep,Sleep_Disturbances
+P001,*************,*************,72,3500,Low,New York,6,Frequent Waking
+P002,*************,*************,65,5000,Moderate,Los Angeles,7,No Waking
+P003,*************,*************,80,1000,Very Low,Chicago,5,Frequent Waking
+P004,*************,*************,70,8000,High,Miami,8,No Waking

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -57,7 +57,7 @@ resource "aws_ecs_task_definition" "ecs_task_transform" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = "${aws_cloudwatch_log_group.ecs_log_group_transform.name}"
-          awslogs-region        = "us-west-1" # Change to your region
+          awslogs-region        = var.region
           awslogs-stream-prefix = "ecs"
         }
       }
@@ -88,7 +88,7 @@ resource "aws_ecs_task_definition" "ecs_task_validate" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = "${aws_cloudwatch_log_group.ecs_log_group_validate.name}"
-          awslogs-region        = "us-west-1" # Change to your region
+          awslogs-region        = var.region
           awslogs-stream-prefix = "ecs"
         }
       }
@@ -125,34 +125,3 @@ resource "aws_security_group" "ecs_sg" {
     cidr_blocks = ["0.0.0.0/0"] # Needed for ECR, S3, Logs, etc.
   }
 }
-
-# ---------------------------------------
-# Create and ECS Service
-# ---------------------------------------
-# resource "aws_ecs_service" "ecs_service_transform" {
-#   name            = "ecs-service-5201201-transform"
-#   cluster         = aws_ecs_cluster.ecs_cluster.id
-#   task_definition = aws_ecs_task_definition.ecs_task_transform.arn
-#   desired_count   = 1
-#   launch_type     = "FARGATE"
-
-#   network_configuration {
-#     subnets         = var.private_subnets
-#     security_groups = [aws_security_group.ecs_sg.id]
-#     assign_public_ip = false
-#   }
-# }
-
-# resource "aws_ecs_service" "ecs_service_validate" {
-#   name            = "ecs-service-5201201-validate"
-#   cluster         = aws_ecs_cluster.ecs_cluster.id
-#   task_definition = aws_ecs_task_definition.ecs_task_validate.arn
-#   desired_count   = 1
-#   launch_type     = "FARGATE"
-
-#   network_configuration {
-#     subnets         = var.private_subnets
-#     security_groups = [aws_security_group.ecs_sg.id]
-#     assign_public_ip = false
-#   }
-# }

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -3,6 +3,9 @@
 # 
 # This file defines input variables for the ECS module.
 # ================================================================
+variable "region" {
+    type = string
+}
 
 variable "vpc_id" {
   type = string

--- a/terraform/lambda/main.tf
+++ b/terraform/lambda/main.tf
@@ -12,3 +12,4 @@ resource "aws_lambda_function" "process_raw_data" {
   source_code_hash = filebase64sha256("./lambda/lambda_function.zip")
 }
 
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,13 +7,17 @@
 # Handles S3 buckets for raw data and scripts storage
 #---------------------------------------------------------------
 module "s3" {
-  source               = "./s3"
-  raw_bucket_name      = "raw-prd-5201201"
-  scripts_bucket_name  = "scripts-5201201"
-  oper_bucket_name     = "oper-5201201"
-  audit_bucket_name    = "audit-5201201"
-  output_bucket_name   = "output-5201201"
-  appdata_bucket_name = "appdata-5201201"
+  source                             = "./s3"
+  region                             = var.region
+  raw_bucket_name                    = "raw-prd-5201201"
+  scripts_bucket_name                = "scripts-5201201"
+  oper_bucket_name                   = "oper-5201201"
+  audit_bucket_name                  = "audit-5201201"
+  output_bucket_name                 = "output-5201201"
+  appdata_bucket_name                = "appdata-5201201"
+  s3_access_point_name               = "s3-access-point-5201201"
+  s3_object_lambda_access_point_name = "s3-object-lambda-access-point-5201201"
+  s3_object_lambda_access_point_arn  = "arn:aws:lambda:us-west-2:525425830681:function:serverlessrepo-ComprehendPiiR-PiiRedactionFunction-0JkwowHd0ZnO"
 
   tags = {
     "Project"     = "SDTM-52012-01"
@@ -94,6 +98,7 @@ module "vpc" {
 #---------------------------------------------------------------
 module "ecs" {
   source            = "./ecs"
+  region            = var.region
   vpc_id            = module.vpc.vpc_id
   private_subnets   = module.vpc.private_subnets
   oper_bucket_arn   = module.s3.oper_bucket_arn

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -14,5 +14,5 @@ terraform {
 # AWS Provider Configuration
 # =============================================================
 provider "aws" {
-  region = "us-west-1"
+  region = var.region
 }

--- a/terraform/s3/variables.tf
+++ b/terraform/s3/variables.tf
@@ -4,6 +4,11 @@
 # This file defines input variables for the s3 module.
 # ================================================================
 
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
 variable "raw_bucket_name" {
   type        = string
   description = "The name of the S3 bucket for raw data"
@@ -32,6 +37,21 @@ variable "audit_bucket_name" {
   variable "appdata_bucket_name" {
    type        = string
    description = "The name of the S3 bucket for app data"
+ }
+
+   variable "s3_access_point_name" {
+   type        = string
+   description = "The name of the S3 access point name"
+ }
+
+  variable "s3_object_lambda_access_point_name" {
+   type        = string
+   description = "The name of the S3 object lambda access point name"
+ }
+
+   variable "s3_object_lambda_access_point_arn" {
+   type        = string
+   description = "The name of the S3 object lambda access point ARN"
  }
 
 variable "tags" {

--- a/terraform/step_functions/main.tf
+++ b/terraform/step_functions/main.tf
@@ -24,8 +24,8 @@ resource "aws_sfn_state_machine" "my_state_machine" {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
-        "FunctionName": "arn:aws:lambda:us-west-1:525425830681:function:process_raw_data:$LATEST",
-        "Payload.$": "$"
+        "FunctionName": "arn:aws:lambda:us-west-2:525425830681:function:process_raw_data:$LATEST",
+        "Payload.$": "$" 
       },
       "Retry": [
         {
@@ -124,7 +124,7 @@ resource "aws_sfn_state_machine" "my_state_machine" {
       "Resource": "arn:aws:states:::ecs:runTask",
       "Parameters": {
         "LaunchType": "FARGATE",
-        "Cluster": "arn:aws:ecs:us-west-1:525425830681:cluster/ecs-cluster-5201201",
+        "Cluster": "arn:aws:ecs:us-west-2:525425830681:cluster/ecs-cluster-5201201",
         "TaskDefinition": "${var.ecs_task_transform_arn}",
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
@@ -154,7 +154,7 @@ resource "aws_sfn_state_machine" "my_state_machine" {
       "Resource": "arn:aws:states:::ecs:runTask",
       "Parameters": {
         "LaunchType": "FARGATE",
-        "Cluster": "arn:aws:ecs:us-west-1:525425830681:cluster/ecs-cluster-5201201",
+        "Cluster": "arn:aws:ecs:us-west-2:525425830681:cluster/ecs-cluster-5201201",
         "TaskDefinition": "${var.ecs_task_validate_arn}",
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
@@ -183,7 +183,7 @@ resource "aws_sfn_state_machine" "my_state_machine" {
       "Type": "Task",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
-        "TopicArn": "arn:aws:sns:us-west-1:525425830681:sns-topic-5201201",
+        "TopicArn": "arn:aws:sns:us-west-2:525425830681:sns-topic-5201201",
         "Subject": "ECS Task Failure Notification",
         "Message.$": "$"
       },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,10 @@
+# ================================================================
+# Root Module - Variables
+# 
+# This file defines input variables for the Root module.
+# ================================================================
+variable "region" {
+  type        = string
+  default     = "us-west-2"
+  description = "AWS Region"
+}


### PR DESCRIPTION
RESOLVED:
> The error "UNSUPPORTED_OPERATION: This operation is not supported in this region" means that Amazon Comprehend's PII detection is not available in your AWS region.

Solution: Change the AWS Region. Change pipeline deployment to `us-west-2`.

NOTE: 

When specifying PII redaction entities, ensure no spaces between entity types:
`
NAME,EMAIL,DATE_TIME,PHONE,ADDRESS,PASSWORD,USERNAME,IP_ADDRESS`

---

Attached the following policies to function execution role:
`AWSLambdaBasicExecutionRole`

---

Sample calls:
```
aws s3api get-object \
  --bucket arn:aws:s3-object-lambda:us-west-2:525425830681:accesspoint/s3-object-lambda-access-point-5201201 \
  --key medication_use_symptoms_02102023.csv \
  medication_use_symptoms_02102023_REDACTED.csv
  
  aws s3api get-object \
  --bucket arn:aws:s3-object-lambda:us-west-2:525425830681:accesspoint/s3-object-lambda-access-point-5201201 \
  --key raw_patient_reported_outcomes_02102023.csv \
  raw_patient_reported_outcomes_02102023_REDACTED.csv
  
  aws s3api get-object \
  --bucket arn:aws:s3-object-lambda:us-west-2:525425830681:accesspoint/s3-object-lambda-access-point-5201201 \
  --key raw_wearable_device_02102023.csv \
  raw_wearable_device_02102023_REDACTED.csv
```
---

REDACTED:
```
Patient_ID,Name,Email,Date,Time,Medications,Symptom_Score,Pain_Level,Symptoms,Location
P001,********,******************,*************:30,NSAID,3,7,Cramping; Fatigue,********
P002,***********,*********************,*************:00,NSAID,2,3,No Symptoms,***********
P003,*************,***********************,*************:00,NSAID,4,9,Heavy Bleeding; Fatigue,*******
P004,*************,***********************,*************:30,No Medication,1,2,Happy,*****
```
  