### PR TITLE
Updated step functions workflow with wait states for ECS tasks and output bucket crawler

### DIFF
--- a/terraform/glue/main.tf
+++ b/terraform/glue/main.tf
@@ -12,6 +12,9 @@ resource "aws_glue_catalog_database" "glue_database" {
 # ---------------------------------------
 # Create Crawler
 # ---------------------------------------
+
+# Raw/Landing bucket crawler
+# TODO: Rename this to raw_crawler
 resource "aws_glue_crawler" "glue_crawler" {
   name          = "crawler-5201201"
   role          = aws_iam_role.glue_service_role.arn
@@ -22,6 +25,19 @@ resource "aws_glue_crawler" "glue_crawler" {
     path = "s3://${var.raw_bucket_name}"
   }
 }
+
+# Output bucket crawler
+resource "aws_glue_crawler" "output_crawler" {
+  name          = "output-crawler-5201201"
+  role          = aws_iam_role.glue_service_role.arn
+  database_name = aws_glue_catalog_database.glue_database.name
+
+  # Define Datata Sources
+  s3_target {
+    path = "s3://${var.output_bucket_name}"
+  }
+}
+
 # ---------------------------------------
 # Glue Job Script
 # ---------------------------------------
@@ -30,6 +46,7 @@ resource "aws_s3_object" "glue_script" {
   key    = "glue_data_quality.py"
   source = "./glue/glue_data_quality.py"
 }
+
 # ---------------------------------------
 # Create Data Quality Job
 # ---------------------------------------

--- a/terraform/glue/outputs.tf
+++ b/terraform/glue/outputs.tf
@@ -8,6 +8,10 @@ output "glue_crawler_arn" {
   value = aws_glue_crawler.glue_crawler.arn
 }
 
+output "output_crawler_arn" {
+  value = aws_glue_crawler.output_crawler.arn
+}
+
 output "glue_job_arn" {
   value = aws_glue_job.data_quality_job.arn
 }

--- a/terraform/glue/roles.tf
+++ b/terraform/glue/roles.tf
@@ -36,7 +36,8 @@ resource "aws_iam_policy" "glue_s3_policy" {
         ],
         "Resource": [
           "${var.raw_bucket_arn}/*",
-          "${var.scripts_bucket_arn}/*"
+          "${var.scripts_bucket_arn}/*",
+          "${var.output_bucket_arn}/*"
         ]
       }
     ]

--- a/terraform/glue/variables.tf
+++ b/terraform/glue/variables.tf
@@ -14,10 +14,10 @@ variable "scripts_bucket_name" {
   description = "The name of the S3 bucket for scripts"
 }
 
-#  variable "output_bucket_name" {
-#    type        = string
-#    description = "The name of the S3 bucket for output"
-#  }
+ variable "output_bucket_name" {
+   type        = string
+   description = "The name of the S3 bucket for output"
+ }
 
 variable "raw_bucket_arn" {
   description = "The ARN of the raw S3 bucket"
@@ -28,4 +28,10 @@ variable "scripts_bucket_arn" {
   description = "The ARN of the scripts S3 bucket"
   type        = string
 }
+
+variable "output_bucket_arn" {
+  description = "The ARN of the output S3 bucket"
+  type        = string
+}
+
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,8 +44,10 @@ module "glue" {
   # Inputs from the S3 module
   raw_bucket_name     = module.s3.raw_bucket_name
   scripts_bucket_name = module.s3.scripts_bucket_name
+  output_bucket_name  = module.s3.output_bucket_name
   raw_bucket_arn      = module.s3.raw_bucket_arn
   scripts_bucket_arn  = module.s3.scripts_bucket_arn
+  output_bucket_arn   = module.s3.output_bucket_arn
 }
 
 #---------------------------------------------------------------
@@ -59,8 +61,9 @@ module "step_functions" {
   lambda_function_arn = module.lambda.process_raw_data_arn
 
   # Inputs from the Glue module
-  glue_crawler_arn = module.glue.glue_crawler_arn
-  glue_job_arn     = module.glue.glue_job_arn
+  glue_crawler_arn   = module.glue.glue_crawler_arn
+  output_crawler_arn = module.glue.output_crawler_arn
+  glue_job_arn       = module.glue.glue_job_arn
 
   # Inputs from SNS module
   sns_topic_arn = module.sns.sns_topic_arn

--- a/terraform/step_functions/roles.tf
+++ b/terraform/step_functions/roles.tf
@@ -38,7 +38,10 @@ resource "aws_iam_policy" "step_function_policy" {
         "glue:StartCrawler",
         "glue:GetCrawler"
     ],
-      "Resource": "${var.glue_crawler_arn}"
+      "Resource": [
+        "${var.glue_crawler_arn}",
+        "${var.output_crawler_arn}"
+    ]
     },
     {
       "Effect": "Allow",
@@ -87,7 +90,8 @@ resource "aws_iam_policy" "step_function_policy" {
       ],
       "Resource": [
         "${var.ecs_task_transform_arn}",
-        "${var.ecs_task_validate_arn}"
+        "${var.ecs_task_validate_arn}",
+        "arn:aws:ecs:us-west-2:525425830681:task/*"
     ]
     },
     {

--- a/terraform/step_functions/variables.tf
+++ b/terraform/step_functions/variables.tf
@@ -6,8 +6,14 @@
 
 variable glue_crawler_arn {
   type        = string
-  description = "ARN of the Glue Crawler"
+  description = "ARN of the Glue Raw bucket Glue crawler"
 }
+
+variable output_crawler_arn {
+  type        = string
+  description = "ARN of the Output bucket Glue crawler"
+}
+
 variable glue_job_arn {
   type        = string
   description = "ARN of the Glue Data Quality Job"


### PR DESCRIPTION
`BUG`: Encountered issue where data in the OPER bucket was not copying to the OUTPUT bucket during p21 simulation run. Since ECS tasks take ~ 2 mins to complete, the VALIDATE task was executing before the TRANSFORM task completed. 

`SOLUTION`: Added wait states of 2 mins between ESC tasks.