### PR TITLE
Updated ECS Fargate task definitions to include Datadog agent containers

### DIFF
--- a/terraform/ecs/roles.tf
+++ b/terraform/ecs/roles.tf
@@ -24,14 +24,20 @@ resource "aws_iam_role" "ecs_task_execution_role" {
   })
 }
 
-# Attach AWS managed Policy for ECS Task Execution Role
+# Attach AWS managed policy for ECS Task Execution Role
 resource "aws_iam_policy_attachment" "ecs_task_execution_attachment" {
   name       = "ecs-task-execution-policy"
   roles      = [aws_iam_role.ecs_task_execution_role.name]
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-# Attach custom S3 access policy to ECS Task Role
+# ------------------------------------------------------
+# Custom policies: s3, Datadog
+# ------------------------------------------------------
+
+# -- S3 --
+
+# Add custom S3 access policy to ECS Execution Role
 resource "aws_iam_policy" "ecs_s3_policy" {
   name        = "ecsS3Policy"
   description = "Policy to allow ECS tasks to read and write to S3 buckets"
@@ -60,4 +66,34 @@ resource "aws_iam_policy_attachment" "ecs_s3_policy_attachment" {
   name       = "ecs-s3-policy-attachment"
   roles      = [aws_iam_role.ecs_task_execution_role.name]
   policy_arn = aws_iam_policy.ecs_s3_policy.arn
+}
+
+# -- Datadog --
+
+# Add custom policy for Datadog permissions
+resource "aws_iam_policy" "ecs_datadog_policy" {
+  name        = "ecsDatadogPolicy"
+  description = "Permissions for Datadog to interact with ECS"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+          "ecs:ListClusters",
+          "ecs:ListContainerInstances",
+          "ecs:DescribeContainerInstances"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Attach the custom Datadog policy to ECS Execution Role
+resource "aws_iam_policy_attachment" "ecs_datadog_policy_attachment" {
+  name       = "ecs-datadog-policy-attachment"
+  roles      = [aws_iam_role.ecs_task_execution_role.name]
+  policy_arn = aws_iam_policy.ecs_datadog_policy.arn
 }

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -31,4 +31,6 @@ variable "output_bucket_arn" {
   type        = string
 }
 
-
+variable "datadog_api_key" {
+    type = string
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -108,6 +108,9 @@ module "ecs" {
   oper_bucket_arn   = module.s3.oper_bucket_arn
   audit_bucket_arn  = module.s3.audit_bucket_arn
   output_bucket_arn = module.s3.output_bucket_arn
+
+  # Inputs from Datadog (terraform.secrets.tfvars)
+  datadog_api_key = var.datadog_api_key
 }
 
 #---------------------------------------------------------------

--- a/terraform/medication_use_symptoms_02102023_REDACTED.csv
+++ b/terraform/medication_use_symptoms_02102023_REDACTED.csv
@@ -1,0 +1,5 @@
+Patient_ID,Name,Email,Date,Time,Medications,Symptom_Score,Pain_Level,Symptoms,Location
+P001,********,******************,*************:30,NSAID,3,7,Cramping; Fatigue,********
+P002,***********,*********************,*************:00,NSAID,2,3,No Symptoms,***********
+P003,*************,***********************,*************:00,NSAID,4,9,Heavy Bleeding; Fatigue,*******
+P004,*************,***********************,*************:30,No Medication,1,2,Happy,*****

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -7,6 +7,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.83"
     }
+    datadog = {
+      source = "DataDog/datadog"
+    }
   }
 }
 
@@ -15,4 +18,8 @@ terraform {
 # =============================================================
 provider "aws" {
   region = var.region
+}
+
+provider "datadog" {
+  api_key = var.datadog_api_key
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,3 +17,4 @@ variable "s3_object_lambda_access_point_arn" {}
 variable "tags" {
   type = map(string)
 }
+variable "datadog_api_key" {}


### PR DESCRIPTION
Following Datadog integration documentation for ECS Fargate containers:
[https://docs.datadoghq.com/integrations/ecs_fargate/?tab=webui](url)

To fully integrate Datadog into the AWS data pipeline, will need to do two things:
1. Install the Datadog Agent on ECS containers.
2. Integrate Datadog with CloudWatch to monitor the other AWS services that the pipeline uses (like S3, Glue, Step Functions, etc.).

This pull request corresponds to the section "[Create an ECS Fargate task](https://docs.datadoghq.com/integrations/ecs_fargate/?tab=webui#create-an-ecs-fargate-task)"
