### PR TITLE
Removing Datadog agent from ECS containers and used Datadog Integraton + Forwarder instead

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -62,36 +62,6 @@ resource "aws_ecs_task_definition" "ecs_task_transform" {
           awslogs-stream-prefix = "ecs"
         }
       }
-    },
-    # Datadog Agent Container
-    {
-      name      = "datadog-agent",
-      image     = "public.ecr.aws/datadog/agent:latest",
-      memory    = 256,
-      cpu       = 128,
-      essential = true,
-      environment = [
-        {
-          name  = "DD_API_KEY",
-          value = var.datadog_api_key # Pass API key here
-        },
-        {
-          name  = "ECS_FARGATE",
-          value = "true"
-        },
-        {
-          name  = "DD_SITE",
-          value = "datadoghq.com"
-        }
-      ],
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-group         = "/ecs/datadog-agent"
-          awslogs-region        = var.region
-          awslogs-stream-prefix = "datadog"
-        }
-      }
     }
   ])
   requires_compatibilities = ["FARGATE"]
@@ -124,36 +94,6 @@ resource "aws_ecs_task_definition" "ecs_task_validate" {
           awslogs-stream-prefix = "ecs"
         }
       }
-    },
-    # Datadog Agent Container
-    {
-      name      = "datadog-agent",
-      image     = "public.ecr.aws/datadog/agent:latest",
-      memory    = 256,
-      cpu       = 128,
-      essential = true,
-      environment = [
-        {
-          name  = "DD_API_KEY",
-          value = var.datadog_api_key  # Pass API key here
-        },
-        {
-          name  = "ECS_FARGATE",
-          value = "true"
-        },
-        {
-          name  = "DD_SITE",
-          value = "datadoghq.com"
-        }
-      ],
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-group         = "/ecs/datadog-agent"
-          awslogs-region        = var.region
-          awslogs-stream-prefix = "datadog"
-        }
-      }
     }
   ])
   requires_compatibilities = ["FARGATE"]
@@ -163,7 +103,6 @@ resource "aws_ecs_task_definition" "ecs_task_validate" {
   memory                   = "1024"
   cpu                      = "512"
 }
-
 
 # ---------------------------------------
 # Create a Security Group

--- a/terraform/step_functions/main.tf
+++ b/terraform/step_functions/main.tf
@@ -8,6 +8,12 @@
 # - ARN and resource IDs are parameterized to avoid hardcoding values that change per deployment.
 # ============================================================
 
+# Create a CloudWatch log group
+resource "aws_cloudwatch_log_group" "step_functions_log_group" {
+  name              = "/aws/stepfunctions/state-machine-5201201"
+  retention_in_days = 30
+}
+
 # ---------------------------------------
 # State Function State Machine
 # ---------------------------------------
@@ -234,4 +240,10 @@ resource "aws_sfn_state_machine" "my_state_machine" {
   }
 }
 ASL
+
+logging_configuration {
+  log_destination        = "${aws_cloudwatch_log_group.step_functions_log_group.arn}:*"
+  include_execution_data = true
+  level                  = "ALL"
+}
 }

--- a/terraform/step_functions/roles.tf
+++ b/terraform/step_functions/roles.tf
@@ -26,7 +26,7 @@ JSON
 
 resource "aws_iam_policy" "step_function_policy" {
   name        = "step-function-policy"
-  description = "Policy for Step Functions to interact with Lambda, Glue, X-Ray, SNS, and ECS"
+  description = "Policy for Step Functions to interact with Lambda, Glue, X-Ray, SNS, ECS, and CloudWatch Logs"
 
   policy = <<JSON
 {
@@ -37,11 +37,11 @@ resource "aws_iam_policy" "step_function_policy" {
       "Action": [
         "glue:StartCrawler",
         "glue:GetCrawler"
-    ],
+      ],
       "Resource": [
         "${var.glue_crawler_arn}",
         "${var.output_crawler_arn}"
-    ]
+      ]
     },
     {
       "Effect": "Allow",
@@ -80,7 +80,7 @@ resource "aws_iam_policy" "step_function_policy" {
         "${var.ecs_cluster_arn}",
         "${var.ecs_task_transform_arn}",
         "${var.ecs_task_validate_arn}"
-    ]
+      ]
     },
     {
       "Effect": "Allow",
@@ -92,12 +92,28 @@ resource "aws_iam_policy" "step_function_policy" {
         "${var.ecs_task_transform_arn}",
         "${var.ecs_task_validate_arn}",
         "arn:aws:ecs:us-west-2:525425830681:task/*"
-    ]
+      ]
     },
     {
       "Effect": "Allow",
       "Action": "iam:PassRole",
       "Resource": "${var.ecs_task_execution_role_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogDelivery",
+        "logs:CreateLogStream",
+        "logs:GetLogDelivery",
+        "logs:UpdateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:PutLogEvents",
+        "logs:PutResourcePolicy",
+        "logs:DescribeResourcePolicies",
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": "*"
     }
   ]
 }
@@ -109,9 +125,3 @@ resource "aws_iam_role_policy_attachment" "step_function_policy_attachment" {
   policy_arn = aws_iam_policy.step_function_policy.arn
   role       = aws_iam_role.step_function_role.name
 }
-
-# Attach AWS managed ECS Task Execution Policy
-# resource "aws_iam_role_policy_attachment" "ecs_task_execution_attachment" {
-#   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-#   role       = aws_iam_role.step_function_role.name
-# }


### PR DESCRIPTION
Removed the datadog agent from the ECS containers, since it doesn't work for this use case. Instead, used Ddatadog AWS integration + Datadog Forwarder. My containers are ephemeral, so DD agent isn't able to pull the information.

- https://docs.datadoghq.com/logs/guide/forwarder/?tab=terraform
- https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/?tab=awsconsole

Might consider defining the Datadog integration + Forwarding in Terraform.